### PR TITLE
Fixed comparability with unicode-math 0.8d

### DIFF
--- a/cv-friggeri-x.cls
+++ b/cv-friggeri-x.cls
@@ -75,7 +75,7 @@
 %%%%%%%%%
 
 \RequirePackage[quiet]{fontspec}
-\RequirePackage[math-style=TeX,vargreek-shape=unicode]{unicode-math}
+\RequirePackage[math-style=TeX]{unicode-math}
 
 \newfontfamily\bodyfont[]{Roboto}
 \newfontfamily\thinfont[]{Roboto Thin}


### PR DESCRIPTION
As of unicode-math 0.8d (see [unicode-math README.md](https://www.ctan.org/pkg/unicode-math)) the `vargreek-shape` option has been removed for compatibility. As such, I have removed the use of this option in the template.