### PR TITLE
Fixing: illegal parameter number in definition of \blx@defformat@d. …

### DIFF
--- a/cv-friggeri-x.cls
+++ b/cv-friggeri-x.cls
@@ -327,7 +327,7 @@
 
 \DeclareNameFormat{author}{%
   \small\addfontfeature{Color=lightgray}%
-  \ifblank{#3}{}{#3\space}#1%
+  \nameparts{#1}\ifblank{\namepartgiven}{}{\namepartgiven\space}\namepartfamily%
   \ifthenelse{\value{listcount}<\value{liststop}}
     {\addcomma\space}
     {}%


### PR DESCRIPTION
…\ifblank{#3}{}{#3

I was getting the following error:

```
! Illegal parameter number in definition of \blx@defformat@d.
<to be read again>
                   3
l.330   \ifblank{#3
                   }{}{#3\space}#1%
?

```

To overcome this, I found this [issue](https://github.com/depressiveRobot/friggeri-cv-a4/issues/3)
on a similar project talking about the same problem. It seems that it's
related to a biblatex update ([source](https://tex.stackexchange.com/questions/299036/biblatex-3-3-name-formatting)).

So, I copied the line 330 of [friggeri-cv-a4](https://github.com/depressiveRobot/friggeri-cv-a4)
to this one. This, apparently, solved the problem.

This are my xelatex and biber versions:

```
daniel@vm-1604:~/projects/cv-friggeri-x-daniel$ xelatex -v
XeTeX 3.14159265-2.6-0.99992 (TeX Live 2015/Debian)
kpathsea version 6.2.1
Copyright 2015 SIL International, Jonathan Kew and Khaled Hosny.
There is NO warranty.  Redistribution of this software is
covered by the terms of both the XeTeX copyright and
the Lesser GNU General Public License.
For more information about these matters, see the file
named COPYING and the XeTeX source.
Primary author of XeTeX: Jonathan Kew.
Compiled with ICU version 55.1; using 55.1
Compiled with zlib version 1.2.8; using 1.2.8
Compiled with FreeType2 version 2.5.5; using 2.5.5
Compiled with Graphite2 version 1.3.6; using 1.3.10
Compiled with HarfBuzz version 1.0.1; using 1.0.1
Compiled with libpng version 1.6.17; using 1.6.17
Compiled with poppler version 0.41.0
Compiled with fontconfig version 2.11.1; using 2.11.94

daniel@vm-1604:~/projects/cv-friggeri-x-daniel$ biber -v
biber version: 2.4

```